### PR TITLE
Update cluster2.md

### DIFF
--- a/dais/clusters/cluster2.md
+++ b/dais/clusters/cluster2.md
@@ -10,7 +10,6 @@ and, in some cases, a demonstration or presentation video.
 
 ## Control and Architecture of SDC
 * [Robust Network & Learning Architectures for SDC](/2a01/)
-* [Service placement and Topology Inference - Replaced by 2a03 & 2a04?](/2a02/)
 * [Topology Inference](/2a03/)
 * [Service Placement](/2a04/)
 * [Graph attention networks (GAT) for congestion and mobility prediction](/2a05/)


### PR DESCRIPTION
removing from cluster 2 2a.02 - "Service placement and Topology Inference" which was replaced by 2a03 & 2a04